### PR TITLE
easy way to cite I-Ds

### DIFF
--- a/draft-tailhardat-nmop-incident-management-noria.md
+++ b/draft-tailhardat-nmop-incident-management-noria.md
@@ -54,54 +54,6 @@ informative:
     target: https://www.w3.org/TR/sparql11-federated-query/
     date: March 2013
 
-  I.D.draft-marcas-nmop-knowledge-graph-yang:
-    title: "Knowledge Graphs for YANG-based Network Management"
-    seriesinfo:
-      Internet-Draft: draft-marcas-nmop-knowledge-graph-yang-03
-    author:
-      - name: I.D. Martinez-Casanueva
-      - name: L. Cabanillas
-    target: https://datatracker.ietf.org/doc/draft-marcas-nmop-knowledge-graph-yang/
-    date: 5 July 2024
-
-  I.D.draft-netana-nmop-network-anomaly-lifecycle:
-    author:
-      - name: A. Roberto
-      - name: T. Graf
-      - name: W. Du
-      - name: A. Huang Feng
-    title: "Experiment: Network Anomaly Lifecycle"
-    seriesinfo:
-      Internet-Draft: draft-netana-nmop-network-anomaly-lifecycle-03
-    date: 8 July 2024
-    target: https://datatracker.ietf.org/doc/draft-netana-nmop-network-anomaly-lifecycle/
-
-  I.D.draft-netana-nmop-network-anomaly-semantics:
-    author:
-      - name: T. Graf
-      - name: W. Du
-      - name: A. Huang Feng
-      - name: V. Riccobene
-      - name: A. Roberto
-    title: "Semantic Metadata Annotation for Network Anomaly Detection"
-    seriesinfo:
-      Internet-Draft: draft-netana-nmop-network-anomaly-semantics-02
-    date: 7 July 2024
-    target: https://datatracker.ietf.org/doc/draft-netana-nmop-network-anomaly-semantics/
-
-  I.D.draft-boucadair-nmop-rfc3535-20years-later:
-    author:
-      - name: Mohamed Boucadair
-      - name: Luis M. Contreras
-      - name: Oscar Gonzalez de Dios
-      - name: Thomas Graf
-      - name: Reshad Rahman
-    title: "RFC 3535, 20 Years Later: An Update of Operators Requirements on Network Management Protocols and Modelling"
-    seriesinfo:
-      Internet-Draft: draft-boucadair-nmop-rfc3535-20years-later-04
-    date: 22 July 2024
-    target: https://datatracker.ietf.org/doc/draft-boucadair-nmop-rfc3535-20years-later/
-
   NORIA-O-2024:
     author:
       - name: Lionel Tailhardat
@@ -182,13 +134,13 @@ TODO Abstract
 
 Incident management on telecom and computer networks, whether it is related to infrastructure or cybersecurity issues, requires the ability to simultaneously and quickly correlate and interpret a large number of heterogeneous technical information sources.
 Knowledge Graphs (KGs), by structuring heterogeneous data through shared vocabularies, enable providing a unified view of technical systems,
-their ecosystem, and the activities and operations related to them (see {{I.D.draft-marcas-nmop-knowledge-graph-yang}} and {{NORIA-O-2024}}).
+their ecosystem, and the activities and operations related to them (see {{?I-D.marcas-nmop-knowledge-graph-yang}} and {{NORIA-O-2024}}).
 Using such formal knowledge representation may therefore allows for a simplified interpretation of networks and their behavior, both for users and AI algorithms, and paves the way for the development of tools for analyzing and detecting complex anomalies through explainable, actionable, and shareable models (see {{FOLIO-2018}}, {{SLKG-2023}}, and {{GPL-2024}}).
 
 However, despite potential benefits of using knowledge graphs, these are not mainstream yet in commercial network deployment systems and decision support systems (see {{NORIA-UI-2024}} for more on the decision support systems perspective).
 YANG is a widely used standard among operators for describing network configuration and deployment.
-Using YANG representations in the form of a KG, as suggested in {{I.D.draft-marcas-nmop-knowledge-graph-yang}}, would minimize the effort required to adapt network management tools towards the unified vision and applications evoked above.
-The lack of alignment between various YANG models on key concepts (e.g. for describing network topology) is, however, hindering this evolution {{I.D.draft-boucadair-nmop-rfc3535-20years-later}}.
+Using YANG representations in the form of a KG, as suggested in {{?I-D.marcas-nmop-knowledge-graph-yang}}, would minimize the effort required to adapt network management tools towards the unified vision and applications evoked above.
+The lack of alignment between various YANG models on key concepts (e.g. for describing network topology) is, however, hindering this evolution {{?I-D.boucadair-nmop-rfc3535-20years-later}}.
 
 Furthermore, it can be observed that the scope of YANG models does not naturally cover the description of the networks' ecosystem (e.g. physical equipment location, operator organization, supervision systems) or the description of network operations from an ITSM perspective (e.g. business processes and design rules used by the company, scheduled modification operations, remediation actions performed during incident handling).
 


### PR DESCRIPTION
No need to have explicit ref entries for drafts, RFCs.

These entries will be automatically added if you cited them in the text, e.g., {{?I-D.marcas-nmop-knowledge-graph-yang}}. ("s/?/! if a ref is normative)